### PR TITLE
build: replace deprecated jcenter() with mavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-
         mavenCentral()
         maven { url 'https://jitpack.io' } // Add JitPack repository
     }
@@ -14,7 +12,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         mavenLocal()
 


### PR DESCRIPTION
jcenter() has been sunset by JFrog and is officially deprecated. All required artifacts are already available from google(), mavenCentral(), and jitpack.io.

This change removes the two remaining `jcenter()` declarations from `build.gradle` (one in `buildscript.repositories`, one in `allprojects.repositories`) to eliminate build warnings and prevent future resolution failures.

There is no functional impact — mavenCentral() already exists in both blocks right next to the removed lines. No Java/Kotlin code or build logic is changed.