### PR TITLE
ci: pin appleboy/telegram-action to v1.0.1

### DIFF
--- a/.github/workflows/app-on-push.yml
+++ b/.github/workflows/app-on-push.yml
@@ -61,7 +61,7 @@ jobs:
 
 
       - name: Send commit info to Telegram
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@v1.0.1
         with:
           to: ${{ secrets.TELEGRAM_CHANNEL_ID}}
           token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
             Changes: https://github.com/${{ github.repository }}/commit/${{github.sha}}
 
       - name: Upload Release APK to Telegram
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@v1.0.1
         with:
           to: ${{ secrets.TELEGRAM_CHANNEL_ID }}
           token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -80,7 +80,7 @@ jobs:
           document: ${{ steps.find-release-apk.outputs.release_apk_path }}
 
       - name: Upload Debug APK to Telegram
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@v1.0.1
         with:
           to: ${{ secrets.TELEGRAM_CHANNEL_ID }}
           token: ${{ secrets.TELEGRAM_BOT_TOKEN }}


### PR DESCRIPTION
**Why:** The workflow currently uses `appleboy/telegram-action@master`, a mutable ref that could introduce breaking changes or supply-chain risks if the upstream action's default branch is modified.

**What changed:** Pinned all three occurrences to the latest stable tag `v1.0.1` for reproducible, secure CI builds.

No functional change to the build logic.